### PR TITLE
Refactor Result variants to classes (allow Ok())

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
 import {Maybe} from './lib/Maybe';
-import {Result} from './lib/Result';
+import {Ok, Error} from './lib/Result';
 
-export {Maybe, Result};
+export {Maybe, Ok, Err};


### PR DESCRIPTION
I realized that the current implementation didn't support `Ok()`. In other words, we couldn't make a value that returned a result but no other information (in Rust, this is `Rust(())` where `()` is the unit type). Anyway, I refactored it to use classes (as you asked about a few days back) so we don't necessarily have to return a value.

I believe there are similar issues with `Maybe` as I suspect it will have issues with falsey values - like `Maybe.some(false)`.
